### PR TITLE
Fix Fly deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ Telegram notifications when new deals appear.
 1. Configure the secrets `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `MIN_BONUS`
    and `FLY_API_TOKEN` in your GitHub repository.
 
-2. Deploy to Fly.io with a single command:
+2. Create the Fly.io app (run once):
+
+   ```bash
+   flyctl apps create miles
+   ```
+3. Deploy to Fly.io with a single command:
 
    ```bash
    gh workflow run deploy-fly


### PR DESCRIPTION
## Summary
- clarify that the Fly.io app must be created before deploying

## Testing
- `pytest -q`
- `mypy --strict miles/`


------
https://chatgpt.com/codex/tasks/task_e_68434f409f4483278b9068febccfb8d2