### PR TITLE
Implement daily source search and update schedule

### DIFF
--- a/miles/scheduler.py
+++ b/miles/scheduler.py
@@ -2,13 +2,21 @@ from __future__ import annotations
 
 import asyncio
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from zoneinfo import ZoneInfo
+
 from bonus_alert_bot import run_scan
+from miles.source_search import update_sources
+
+
+TIMEZONE = ZoneInfo("America/Sao_Paulo")
 
 
 def setup_scheduler() -> None:
-    scheduler = AsyncIOScheduler(event_loop=asyncio.get_running_loop())
-    scheduler.add_job(run_scan, "cron", hour=15, minute=0)
-    scheduler.add_job(run_scan, "cron", hour=23, minute=0)
+    loop = asyncio.get_running_loop()
+    scheduler = AsyncIOScheduler(event_loop=loop, timezone=TIMEZONE)
+    scheduler.add_job(update_sources, "cron", hour=6, minute=0)
+    scheduler.add_job(run_scan, "cron", hour=9, minute=0)
+    scheduler.add_job(run_scan, "cron", hour=18, minute=0)
     scheduler.start()
 
 

--- a/miles/source_search.py
+++ b/miles/source_search.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from urllib.parse import urlparse, parse_qs, unquote, quote_plus
+
+import yaml
+import requests
+from bs4 import BeautifulSoup
+
+from bonus_alert_bot import send_telegram, HEADERS, SOURCES_PATH
+
+
+QUERY = "transferencia de pontos bonus milhas"
+
+
+def _extract_urls(html: str) -> list[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    urls: list[str] = []
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if "duckduckgo.com" in urlparse(href).netloc:
+            q = parse_qs(urlparse(href).query).get("uddg")
+            if q:
+                href = unquote(q[0])
+        parsed = urlparse(href)
+        if parsed.scheme.startswith("http") and parsed.netloc:
+            url = f"https://{parsed.netloc}"
+            urls.append(url)
+    return urls
+
+
+def search_new_sources() -> list[str]:
+    url = f"https://duckduckgo.com/html/?q={quote_plus(QUERY)}"
+    try:
+        html = requests.get(url, headers=HEADERS, timeout=15).text
+    except Exception:
+        return []
+    return _extract_urls(html)
+
+
+def update_sources() -> list[str]:
+    try:
+        with open(SOURCES_PATH) as f:
+            current: list[str] = yaml.safe_load(f)
+    except FileNotFoundError:
+        current = []
+    existing = set(current)
+    found: list[str] = []
+    for url in search_new_sources():
+        if url not in existing:
+            current.append(url)
+            existing.add(url)
+            found.append(url)
+    if found:
+        with open(SOURCES_PATH, "w") as f:
+            yaml.safe_dump(current, f, sort_keys=False)
+        try:
+            send_telegram("Novas fontes adicionadas:\n" + "\n".join(found))
+        except Exception:
+            pass
+    return found

--- a/tests/test_source_search.py
+++ b/tests/test_source_search.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+import yaml
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from miles import source_search
+
+
+def test_update_sources(tmp_path, monkeypatch):
+    src_file = tmp_path / "sources.yaml"
+    src_file.write_text("- https://example.com\n")
+    monkeypatch.setattr(source_search, "SOURCES_PATH", str(src_file))
+
+    def fake_search() -> list[str]:
+        return ["https://newsite.com"]
+
+    monkeypatch.setattr(source_search, "search_new_sources", fake_search)
+    monkeypatch.setattr(source_search, "send_telegram", lambda msg: None)
+    added = source_search.update_sources()
+    assert added == ["https://newsite.com"]
+    urls = yaml.safe_load(src_file.read_text())
+    assert "https://newsite.com" in urls


### PR DESCRIPTION
## Summary
- introduce `source_search` for discovering new promo sources
- run new search job at 06:00 America/Sao_Paulo
- adjust alert scheduling to 09:00 and 18:00
- add tests for the new source search logic

## Testing
- `pre-commit run --files miles/source_search.py miles/scheduler.py tests/test_source_search.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c395e6bc8327bc9e051ef4cf6fc6