### PR TITLE
Add persistent ChatGPT mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       - run: pip install -e .
       - run: |
           # install stub packages for mypy strict mode
-          pip install types-PyYAML types-requests
+          pip install types-PyYAML types-requests openai types-openai
       - run: pip install ruff black mypy pytest
       - run: ruff check .
       - run: black --check .

--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -12,6 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: "Push secrets to Fly"
+        run: |
+          fly secrets set \
+            OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }} \
+            TELEGRAM_BOT_TOKEN=${{ secrets.TELEGRAM_BOT_TOKEN }} \
+            TELEGRAM_CHAT_ID=${{ secrets.TELEGRAM_CHAT_ID }} \
+            MIN_BONUS=${{ secrets.MIN_BONUS }} \
+            REDIS_URL=${{ secrets.REDIS_URL }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       - uses: superfly/flyctl-actions@1.5
         with:
           args: "deploy --remote-only"
@@ -21,3 +31,4 @@ jobs:
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           MIN_BONUS: ${{ secrets.MIN_BONUS }}
           REDIS_URL: ${{ secrets.REDIS_URL }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Environment variables:
 - `TELEGRAM_CHAT_ID` – default chat to notify
 - `MIN_BONUS` – minimum bonus percentage to alert (default 80)
 - `SOURCES_PATH` – path to the YAML file with program sources
+- `OPENAI_API_KEY` – required for the `/chat` command
 
 ## Quick start
 
@@ -44,6 +45,12 @@ The companion command bot provides a few utilities:
 - `/sources` – check if each source page is online
 - `/update` – search the web for new sources
 - `/chat <text>` – talk with the integrated AI assistant
+
+## ChatGPT mode
+
+Use `/chat <message>` to converse with the bot. The conversation is kept per
+Telegram user in Redis for up to 30 minutes. Send `/end` to clear the stored
+context. Set `OPENAI_API_KEY` to enable this feature.
 
 ## Example sources
 

--- a/ask_bot.py
+++ b/ask_bot.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import os
 
 import asyncio
+import logging
 from telegram import Update
 from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
+
+import openai
+from miles.chat_store import ChatMemory
 
 from miles.scheduler import setup_scheduler
 from miles.source_search import update_sources
@@ -15,7 +19,11 @@ import bonus_alert_bot as bot
 import yaml
 import requests
 from urllib.parse import urlparse
-from typing import Any
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+if not openai.api_key:
+    logging.warning("OPENAI_API_KEY is not set; /chat may not work")
+memory = ChatMemory()
 
 
 async def ask(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -78,30 +86,38 @@ async def update(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text(msg)
 
 
-async def chat(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Reply using OpenAI ChatCompletion."""
-    if not update.message:
-        return
-    text = update.message.text or ""
-    parts = text.split(" ", 1)
+async def handle_chat(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    text = update.message.text
+    parts = text.split(maxsplit=1)
     if len(parts) < 2:
         await update.message.reply_text("Usage: /chat <message>")
         return
-    await update.message.reply_text("Thinking...")
-    try:
-        import openai
+    user_id = update.effective_user.id
+    user_msgs = memory.get(user_id)
+    user_msgs.append({"role": "user", "content": parts[1]})
 
-        openai.api_key = os.getenv("OPENAI_API_KEY")
-        resp: Any = await asyncio.to_thread(
-            openai.ChatCompletion.create,
-            model="gpt-3.5-turbo",
-            messages=[{"role": "user", "content": parts[1]}],
+    try:
+        resp = await asyncio.to_thread(
+            openai.chat.completions.create,
+            model=os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            messages=user_msgs[-20:],
+            stream=False,
+            temperature=0.7,
         )
-        msg = resp["choices"][0]["message"]["content"].strip()
-    except Exception as e:  # pragma: no cover - network usage
-        await update.message.reply_text(f"Error: {e}")
+        reply = resp.choices[0].message.content
+    except Exception as e:
+        logging.exception("OpenAI call failed")
+        await update.message.reply_text(f"Error: {e.__class__.__name__}: {e}")
         return
-    await update.message.reply_text(msg)
+
+    user_msgs.append({"role": "assistant", "content": reply})
+    memory.save(user_id, user_msgs[-20:])
+    await update.message.reply_text(reply)
+
+
+async def handle_end(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    memory.clear(update.effective_user.id)
+    await update.message.reply_text("\u2702\ufe0f  Chat ended.")
 
 
 async def _post_init(app: object) -> None:
@@ -116,7 +132,8 @@ def main() -> None:
     app.add_handler(CommandHandler("ask", ask))
     app.add_handler(CommandHandler("sources", sources))
     app.add_handler(CommandHandler("update", update))
-    app.add_handler(CommandHandler("chat", chat))
+    app.add_handler(CommandHandler("chat", handle_chat))
+    app.add_handler(CommandHandler("end", handle_end))
     app.run_polling()
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
       - MIN_BONUS=${MIN_BONUS:-0}
       - REDIS_URL=redis://redis:6379/0
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
     depends_on:
       - redis
   redis:

--- a/miles/chat_store.py
+++ b/miles/chat_store.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta  # noqa: F401
+import json
+import os
+from typing import cast
+import redis
+
+
+class ChatMemory:
+    def __init__(self) -> None:
+        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        self.r = redis.Redis.from_url(url, decode_responses=True)
+        self.ttl = int(os.getenv("CHAT_TTL_MINUTES", "30"))
+
+    def _key(self, user_id: int) -> str:
+        return f"chat:{user_id}"
+
+    def get(self, user_id: int) -> list[dict[str, str]]:
+        raw = self.r.get(self._key(user_id))
+        return cast(list[dict[str, str]], json.loads(raw)) if raw else []
+
+    def save(self, user_id: int, messages: list[dict[str, str]]) -> None:
+        self.r.set(self._key(user_id), json.dumps(messages), ex=self.ttl * 60)
+
+    def clear(self, user_id: int) -> None:
+        self.r.delete(self._key(user_id))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "APScheduler>=3.10",
     "redis>=5.0",
     "PyYAML",
+    "openai>=1.27,<2.0",
 ]
 
 [project.optional-dependencies]
@@ -27,7 +28,7 @@ dev = [
     "pytest-cov",
     "pytest-xdist",
     "mypy",
-    "openai>=0.21,<1.0",
+    "types-openai>=0.3",
     "pdfplumber",
     "types-PyYAML>=6.0.12",
     "types-requests>=2.31.0.20240406",


### PR DESCRIPTION
## Summary
- add OpenAI client as a runtime dependency
- create `ChatMemory` backed by Redis
- integrate `/chat` and `/end` commands with persistent history
- wire up OPENAI secrets in CI and Fly deploy
- document ChatGPT usage

## Testing
- `pre-commit run --files .github/workflows/build.yml .github/workflows/deploy-fly.yml .pre-commit-config.yaml README.md ask_bot.py docker-compose.yml pyproject.toml miles/chat_store.py`
- `pytest -q`
- `mypy --strict miles/`


------
https://chatgpt.com/codex/tasks/task_e_6843d8d8e10c8327ae3cd2204adbf131