### PR TITLE
Add runtime source management

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,16 @@ After cloning the repository, run `pre-commit install` to enable local checks.
 
 Edit `sources.yaml` to change which pages are scanned.
 
-### Telegram commands
+### Runtime commands
 
-The companion command bot provides a few utilities:
-
-- `/ask` – run an immediate promotion scan
-- `/sources` – check if each source page is online
-- `/update` – search the web for new sources
-- `/chat <text>` – talk with the integrated AI assistant
+| Command | Action |
+|---------|--------|
+| `/ask` | Run an immediate promotion scan |
+| `/sources` | List current sources |
+| `/addsrc <url>` | Add a new source URL |
+| `/rmsrc <id_or_url>` | Remove a source by index or full URL |
+| `/update` | Search the web for new sources |
+| `/chat <text>` | Talk with the integrated AI assistant |
 
 ## Example sources
 

--- a/ask_bot.py
+++ b/ask_bot.py
@@ -10,12 +10,12 @@ from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
 
 from miles.scheduler import setup_scheduler
 from miles.source_search import update_sources
+from miles.source_store import SourceStore
 
 import bonus_alert_bot as bot
-import yaml
-import requests
-from urllib.parse import urlparse
 from typing import Any
+
+store = SourceStore()
 
 
 async def ask(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -29,40 +29,44 @@ async def ask(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
 
-def _diagnose_sources() -> list[str]:
-    """Return a list of formatted source status lines."""
-    path = os.getenv("SOURCES_PATH", "sources.yaml")
-    try:
-        with open(path) as f:
-            urls: list[str] = yaml.safe_load(f)
-    except Exception:
-        return []
-    results = []
-    for url in urls:
-        name = urlparse(url).netloc
-        try:
-            r = requests.head(
-                url, headers=bot.HEADERS, timeout=10, allow_redirects=True
-            )
-            if r.status_code >= 400:
-                raise ValueError(r.status_code)
-        except Exception:
-            results.append(f"\u274c {name} - {url}")
-        else:
-            results.append(f"\u2705 {name} - {url}")
-    return results
-
-
-async def sources(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Report which sources are responding."""
-    if not update.message:
+async def handle_sources(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    lst = store.all()
+    if not lst:
+        await update.message.reply_text("⚠️  No sources configured.")
         return
-    await update.message.reply_text("Checking sources, please wait...")
-    lines = await asyncio.to_thread(_diagnose_sources)
-    if not lines:
-        await update.message.reply_text("No sources found.")
-        return
+    if len(lst) > 50:
+        extra = len(lst) - 50
+        lst = lst[:50]
+        lines = [f"{i+1}. {u}" for i, u in enumerate(lst)]
+        lines.append(f"… and {extra} more")
+    else:
+        lines = [f"{i+1}. {u}" for i, u in enumerate(lst)]
     await update.message.reply_text("\n".join(lines))
+
+
+async def handle_addsrc(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    parts = update.message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await update.message.reply_text("Usage: /addsrc <url>")
+        return
+    url = parts[1].strip()
+    if store.add(url):
+        await update.message.reply_text("✅ added.")
+    else:
+        await update.message.reply_text("Already present or invalid.")
+
+
+async def handle_rmsrc(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    parts = update.message.text.split(maxsplit=1)
+    if len(parts) < 2:
+        await update.message.reply_text("Usage: /rmsrc <index|url>")
+        return
+    target = parts[1].strip()
+    removed = store.remove(target)
+    if removed:
+        await update.message.reply_text(f"🗑️ removed: {removed}")
+    else:
+        await update.message.reply_text("Not found.")
 
 
 async def update(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -114,7 +118,9 @@ def main() -> None:
         raise SystemExit("TELEGRAM_BOT_TOKEN is not set")
     app = ApplicationBuilder().token(token).post_init(_post_init).build()
     app.add_handler(CommandHandler("ask", ask))
-    app.add_handler(CommandHandler("sources", sources))
+    app.add_handler(CommandHandler("sources", handle_sources))
+    app.add_handler(CommandHandler("addsrc", handle_addsrc))
+    app.add_handler(CommandHandler("rmsrc", handle_rmsrc))
     app.add_handler(CommandHandler("update", update))
     app.add_handler(CommandHandler("chat", chat))
     app.run_polling()

--- a/bonus_alert_bot.py
+++ b/bonus_alert_bot.py
@@ -14,10 +14,10 @@ import warnings
 import requests
 import feedparser
 from bs4 import BeautifulSoup, XMLParsedAsHTMLWarning
-import yaml
 from urllib.parse import urlparse
 from bs4.element import Tag
 import hashlib
+from miles.source_store import SourceStore
 
 warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
 
@@ -26,12 +26,7 @@ MIN_BONUS = int(os.getenv("MIN_BONUS", 80))
 DEBUG_ALWAYS = os.getenv("DEBUG_MODE", "False") == "True"
 TIMEOUT = 25
 
-SOURCES_PATH = os.getenv("SOURCES_PATH", "sources.yaml")
-try:
-    with open(SOURCES_PATH) as f:
-        SOURCES: list[str] = yaml.safe_load(f)
-except FileNotFoundError:
-    SOURCES = []
+STORE = SourceStore(os.getenv("SOURCES_PATH", "sources.yaml"))
 
 HEADERS = {"User-Agent": "Mozilla/5.0 (BonusAlertBot)"}
 PROXY_TPL = [
@@ -184,7 +179,7 @@ def scan_programs(seen: set[str]) -> list[tuple[int, str, str]]:
     """Check all program sources and return found alerts."""
     alerts: list[tuple[int, str, str]] = []
     print(f"=== BonusAlertBot busca ≥ {MIN_BONUS}% ===")
-    for url in SOURCES:
+    for url in STORE.all():
         name = urlparse(url).netloc
         parse_feed(name, url, seen, alerts)
     if DEBUG_ALWAYS and not alerts:

--- a/miles/source_search.py
+++ b/miles/source_search.py
@@ -6,7 +6,10 @@ import yaml
 import requests
 from bs4 import BeautifulSoup, Tag
 
-from bonus_alert_bot import send_telegram, HEADERS, SOURCES_PATH
+from bonus_alert_bot import send_telegram, HEADERS
+import os
+
+SOURCES_PATH = os.getenv("SOURCES_PATH", "sources.yaml")
 
 
 QUERY = "transferencia de pontos bonus milhas"

--- a/miles/source_store.py
+++ b/miles/source_store.py
@@ -1,0 +1,55 @@
+import os
+import redis
+import yaml
+import logging
+from typing import List
+
+
+class SourceStore:
+    def __init__(self, yaml_path: str = "sources.yaml"):
+        self.yaml_path = yaml_path
+        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        self.r = redis.Redis.from_url(url, decode_responses=True)
+        if not self.r.exists("sources"):
+            self._bootstrap_from_yaml()
+
+    def _bootstrap_from_yaml(self) -> None:
+        try:
+            with open(self.yaml_path) as f:
+                data: List[str] = yaml.safe_load(f) or []
+        except FileNotFoundError:
+            data = []
+        if data:
+            self.r.sadd("sources", *data)
+
+    def _flush_to_yaml(self) -> None:
+        with open(self.yaml_path, "w") as f:
+            yaml.safe_dump(sorted(self.all()), f)
+
+    # public API ---------------------------------------------------------
+    def all(self) -> List[str]:
+        return sorted(self.r.smembers("sources"))
+
+    def add(self, url: str) -> bool:
+        if not url.startswith("http") or len(url) > 200:
+            logging.warning("Rejected invalid URL: %s", url)
+            return False
+        added = self.r.sadd("sources", url) == 1
+        if added:
+            self._flush_to_yaml()
+        return added
+
+    def remove(self, token: str) -> str | None:
+        target = None
+        if token.isdigit():
+            try:
+                target = self.all()[int(token) - 1]
+            except IndexError:
+                return None
+        else:
+            target = token
+        removed = self.r.srem("sources", target)
+        if removed:
+            self._flush_to_yaml()
+            return target
+        return None

--- a/tests/test_source_store.py
+++ b/tests/test_source_store.py
@@ -1,0 +1,11 @@
+from miles.source_store import SourceStore
+
+
+def test_add_remove(tmp_path, monkeypatch):
+    yaml_path = tmp_path / "src.yaml"
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/1")
+    s = SourceStore(str(yaml_path))
+    assert s.add("http://a.com")
+    assert "http://a.com" in s.all()
+    assert s.remove("1") == "http://a.com"
+    assert not s.all()


### PR DESCRIPTION
## Summary
- store program URLs in Redis with `SourceStore`
- allow Telegram users to list/add/remove sources
- use `SourceStore` in the bonus scanner
- document runtime commands
- test new storage class

## Testing
- `pytest -q`
- `redis-cli -u redis://localhost:6379/1 FLUSHDB`
- `mypy --strict miles/`
- `pre-commit run --files miles/source_store.py bonus_alert_bot.py ask_bot.py miles/source_search.py README.md tests/test_source_store.py`

------
https://chatgpt.com/codex/tasks/task_e_6843daa50e90832782db1cdb644f4e01