### PR TITLE
Enable fakeredis and remove blocking plot code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ seen.json
 .env
 pytest_cache/
 *.egg-info/
+history/

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To run everything locally:
 docker compose up
 ```
 
-After cloning the repository, run `pre-commit install` to enable local checks.
+After cloning the repository, run `pip install -e .[dev] && pre-commit install` to enable local checks.
 
 Edit `sources.yaml` to change which pages are scanned.
 

--- a/ask_bot.py
+++ b/ask_bot.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import sys
 
 import asyncio
 import logging
@@ -18,9 +17,6 @@ from miles.source_search import update_sources
 from miles.source_store import SourceStore
 
 import bonus_alert_bot as bot
-import yaml
-import requests
-from urllib.parse import urlparse
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 

--- a/miles/chat_store.py
+++ b/miles/chat_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta  # noqa: F401
 import json
 import os
-from typing import cast
+from typing import cast, Optional
 import redis
 import sys
 
@@ -12,7 +12,9 @@ class ChatMemory:
     def __init__(self) -> None:
         url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
         try:
-            self.r = redis.Redis.from_url(url, decode_responses=True)
+            self.r: Optional[redis.Redis[str]] = redis.Redis.from_url(
+                url, decode_responses=True
+            )
             # Test connection
             self.r.ping()
         except Exception as e:

--- a/miles/source_store.py
+++ b/miles/source_store.py
@@ -2,7 +2,7 @@ import os
 import redis
 import yaml
 import logging
-from typing import List
+from typing import List, Optional
 import sys
 
 
@@ -11,7 +11,9 @@ class SourceStore:
         self.yaml_path = yaml_path
         url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
         try:
-            self.r = redis.Redis.from_url(url, decode_responses=True)
+            self.r: Optional[redis.Redis[str]] = redis.Redis.from_url(
+                url, decode_responses=True
+            )
             self.r.ping()
         except Exception as e:
             print(f"[source_store] Redis connection failed: {e}", file=sys.stderr)
@@ -20,6 +22,8 @@ class SourceStore:
             self._bootstrap_from_yaml()
 
     def _bootstrap_from_yaml(self) -> None:
+        if not self.r:
+            return
         try:
             with open(self.yaml_path) as f:
                 data: List[str] = yaml.safe_load(f) or []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "types-PyYAML>=6.0.12",
     "types-requests>=2.31.0.20240406",
     "matplotlib",
+    "fakeredis>=2.0",
 ]
 
 [project.scripts]

--- a/stats.py
+++ b/stats.py
@@ -39,8 +39,6 @@ def plot_heatmap(counts: dict[str, list[int]]) -> None:
     Path("stats").mkdir(exist_ok=True)
     plt.tight_layout()
     plt.savefig("stats/heatmap.png")
-    plt.imshow(data, cmap="Blues")
-    plt.show()
 
 
 def main() -> None:

--- a/tests/test_source_store.py
+++ b/tests/test_source_store.py
@@ -1,8 +1,11 @@
+import fakeredis
+import redis
 from miles.source_store import SourceStore
 
 
 def test_add_remove(tmp_path, monkeypatch):
     yaml_path = tmp_path / "src.yaml"
+    monkeypatch.setattr(redis.Redis, "from_url", fakeredis.FakeRedis.from_url)
     monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/1")
     s = SourceStore(str(yaml_path))
     assert s.add("http://a.com")


### PR DESCRIPTION
## Summary
- add fakeredis to dev extras
- patch SourceStore tests to use fakeredis
- guard redis calls with Optional annotations
- remove blocking plot display
- document dev setup and ignore history directory
- drop unused imports flagged by ruff

## Testing
- `pre-commit run --files ask_bot.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68444c6eb2a883279b8334bc868c8326